### PR TITLE
adds license field to prevent npm warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,5 +34,6 @@
     "css",
     "polyfill"
   ],
+  "license": "UNLICENSED",
   "author": "Philip Schatz"
 }


### PR DESCRIPTION
fixes npm complaining about missing field during install

    npm WARN css-polyfills@0.0.16 No license field.